### PR TITLE
Reproduce dbt issue #2899

### DIFF
--- a/dbt_project.yml
+++ b/dbt_project.yml
@@ -15,8 +15,3 @@ clean-targets:
     - "logs"
 
 models:
-  jaffle_shop:
-      materialized: table
-      staging:
-        materialized: view
-        tags: ["staging", "hourly"]

--- a/models/marts/core/dim_customers.sql
+++ b/models/marts/core/dim_customers.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
 with customers as (
 
     select * from {{ ref('stg_customers') }}

--- a/models/marts/core/fct_orders.sql
+++ b/models/marts/core/fct_orders.sql
@@ -1,5 +1,11 @@
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
+{{
+  config(
+    materialized="table",
+  )
+}}
+
 with orders as (
 
     select * from {{ ref('stg_orders') }}

--- a/models/marts/core/intermediate/customer_orders.sql
+++ b/models/marts/core/intermediate/customer_orders.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
 with orders as (
 
     select * from {{ ref('stg_orders') }}

--- a/models/marts/core/intermediate/customer_payments.sql
+++ b/models/marts/core/intermediate/customer_payments.sql
@@ -1,3 +1,9 @@
+{{
+  config(
+    materialized="table",
+  )
+}}
+
 with payments as (
 
     select * from {{ ref('stg_payments') }}

--- a/models/marts/core/intermediate/order_payments.sql
+++ b/models/marts/core/intermediate/order_payments.sql
@@ -1,5 +1,11 @@
 {% set payment_methods = ['credit_card', 'coupon', 'bank_transfer', 'gift_card'] %}
 
+{{
+  config(
+    materialized="table",
+  )
+}}
+
 with payments as (
 
     select * from {{ ref('stg_payments') }}

--- a/models/staging/stg_customers.sql
+++ b/models/staging/stg_customers.sql
@@ -1,3 +1,10 @@
+{{
+  config(
+    materialized="view",
+    tags=["staging", "hourly"],
+  )
+}}
+
 with source as (
 
     {#-

--- a/models/staging/stg_orders.sql
+++ b/models/staging/stg_orders.sql
@@ -1,3 +1,10 @@
+{{
+  config(
+    materialized="view",
+    tags=["staging", "hourly"],
+  )
+}}
+
 with source as (
 
     {#-

--- a/selectors.yml
+++ b/selectors.yml
@@ -1,0 +1,4 @@
+selectors:
+  - name: view
+    definition:
+      "config.materialized:view"


### PR DESCRIPTION
## Assumption
When we declare materializations in models rather than `dbt_packages.yml`, model selection syntax doesn't work as expected.

## What I did in the changes
1. I removed the `jaffle_shop` dictionary under `models:` in `dbt_packages.yml`.
2. Instead, I declare materializations and tags in each model with `{{ config() }}`.
3. Add a selector whose condition is the same as `--models "config.materialized:view"`.

## How to reproduce the issue
The materialization of `dim_customers` is `table`. 
If we select dbt models and schema tests with `config.materialized:view`, `dbt ls` should not return anything.

### Show a list of all resources for `dim_customers`
I made sure the all resources for `dbt_customers`. Indeed, the model and schema tests appeared.
```bash
$ dbt ls | grep dim_customers

jaffle_shop.marts.core.dim_customers
jaffle_shop.schema_test.not_null_dim_customers_customer_id
jaffle_shop.schema_test.relationships_fct_orders_customer_id__customer_id__ref_dim_customers_
jaffle_shop.schema_test.unique_dim_customers_customer_id
```

### Show a list of resources for`dim_customers` selected by `--models "config.materialized:view"`
It returned nothing as expected.
```bash
$ dbt ls --models "config.materialized:view" | grep dim_customers

```

### Show a list of resources for `dim_customers` selected by a selector
It returned only schema tests for `dim_customers`.
```bash
$ dbt ls --selector view | grep dim_customers

jaffle_shop.schema_test.not_null_dim_customers_customer_id
jaffle_shop.schema_test.relationships_fct_orders_customer_id__customer_id__ref_dim_customers_
jaffle_shop.schema_test.unique_dim_customers_customer_id
```